### PR TITLE
Pass tz through to the original datetime.fromtimestamp when inactive

### DIFF
--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -213,7 +213,7 @@ class FakeDatetime(datetime):
                 original_datetime.fromtimestamp(timestamp, utc).replace(tzinfo=tz or TIME_TO_FREEZE.tzinfo)
             )
         else:
-            _datetime = original_datetime.fromtimestamp(timestamp)
+            _datetime = original_datetime.fromtimestamp(timestamp, tz)
 
         return _datetime
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -145,6 +145,14 @@ def test_fromtimestamp_takes_tz_from_frozen_datetime():
         assert dt == expected_dt
 
 
+def test_fromtimestamp_with_tz_when_inactive():
+    timezone = pytz.utc
+    expected_dt = datetime(1970, 1, 1, 0, 0, tzinfo=timezone)
+
+    dt = datetime.fromtimestamp(0, timezone)
+    assert dt == expected_dt
+
+
 def test_isinstance():
     with immobilus('1970-01-01 00:00:00'):
         mocked_dt = datetime.utcnow()


### PR DESCRIPTION
When the `immobilus` decorator / context manager is inactive, we were failing to pass through the tz argument to the original `datetime.fromtimestamp` so were getting an offset-naive `datetime` when an offset-aware `datetime` is expected.

Includes a new test.