### PR TITLE
datetime.utcnow() and datetime.now() should return naive datetimes

### DIFF
--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -182,7 +182,14 @@ class FakeDatetime(datetime):
     def utcnow(cls):
         global TIME_TO_FREEZE
 
-        _datetime = TIME_TO_FREEZE or datetime.utcnow()
+        if TIME_TO_FREEZE:
+            if TIME_TO_FREEZE.tzinfo:
+                _datetime = TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None)
+            else:
+                _datetime = TIME_TO_FREEZE.replace(tzinfo=None)
+        else:
+            _datetime = datetime.utcnow()
+
         return cls.from_datetime(_datetime)
 
     @classmethod
@@ -196,7 +203,7 @@ class FakeDatetime(datetime):
                 if tz:
                     _datetime = TIME_TO_FREEZE.astimezone(tz) + timedelta(hours=TZ_OFFSET)
                 else:
-                    _datetime = TIME_TO_FREEZE + timedelta(hours=TZ_OFFSET)
+                    _datetime = TIME_TO_FREEZE.replace(tzinfo=None) + timedelta(hours=TZ_OFFSET)
             else:
                 _datetime = TIME_TO_FREEZE.replace(tzinfo=tz) + timedelta(hours=TZ_OFFSET)
         else:

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -77,6 +77,15 @@ def test_datetime_now_with_timezone_on_py3():
     assert dt1.tzinfo == pytz.utc
 
 
+@pytest.mark.parametrize('datetime_function', [datetime.utcnow, datetime.now])
+def test_datetime_now_is_naive(datetime_function):
+    assert datetime_function().tzinfo == None
+    with immobilus('2017-10-12'):
+        assert datetime_function().tzinfo == None
+    with immobilus(datetime(2017, 10, 12, tzinfo=pytz.utc)):
+        assert datetime_function().tzinfo == None
+
+
 def test_addition():
     dt = datetime(2016, 1, 1, 10, 15)
 


### PR DESCRIPTION
...unless the `tz` argument is given to `datetime.now()`, in which case an aware `datetime` in that timezone should be returned.

We were mistakenly returning an aware `datetime` if the `TIME_TO_FREEZE` was itself aware. Failing test in first commit demonstrates this, second commit fixes it.