### PR TITLE
Expose direct start & stop functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,24 @@ def test_decorator():
     assert datetime.utcnow() != dt
 ```
 
+#### Directly
+```python
+from immobilus import immobilus
+from datetime import datetime
+
+def test_start_stop():
+
+    dt = datetime(2016, 1, 1)
+    assert datetime.utcnow() != dt
+
+    spell = immobilus('2016-01-01 13:54')
+    assert datetime.utcnow() != dt
+
+    spell.start()
+    assert datetime.utcnow() == dt
+    spell.stop()
+
+    assert datetime.utcnow() != dt
+```
+
 _Special thanks to Éloi Rivard (https://github.com/azmeuk) for contribution._

--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -285,6 +285,12 @@ class immobilus(object):
         return wrapper
 
     def __enter__(self):
+        self.start()
+
+    def __exit__(self, *args):
+        self.stop()
+
+    def start(self):
         global TIME_TO_FREEZE
         global TZ_OFFSET
 
@@ -299,7 +305,7 @@ class immobilus(object):
 
         return self.time_to_freeze
 
-    def __exit__(self, *args):
+    def stop(self):
         global TIME_TO_FREEZE
         global TZ_OFFSET
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -54,6 +54,24 @@ def test_nested_context_manager(datetime_function):
     assert datetime_function() != dt2
 
 
+@pytest.mark.parametrize('datetime_function', [datetime.utcnow, datetime.now])
+def test_start_stop(datetime_function):
+
+    dt = datetime(2016, 1, 1, 13, 54)
+    assert datetime_function() != dt
+
+    spell = immobilus('2016-01-01 13:54')
+    assert datetime_function() != dt
+
+    try:
+        spell.start()
+        assert datetime_function() == dt
+    finally:
+        spell.stop()
+
+    assert datetime_function() != dt
+
+
 def test_datetime_object():
     dt = datetime(1970, 1, 1)
     with immobilus(dt):


### PR DESCRIPTION
These mirror the functions of the same name exposed by the freezegun API for [raw use](https://github.com/spulec/freezegun#raw-use) and can be quite useful for those using standard library style unittest.TestCase

e.g.

```python

import unittest
import immobilus

class SomeTests(unittest.TestCase):
    def setUp(self):
        freezer = immobilus.immobilus("2015-03-15 12:34:56")
        freezer.start()
        self.addCleanup(freezer.stop)
```