### PR TITLE
Problems when freezing with an offset-aware datetime

### DIFF
--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -46,6 +46,7 @@ def _total_seconds(timedelta):
 
 
 def _datetime_to_utc_timestamp(dt):
+    assert dt.tzinfo is None
     delta = dt - original_datetime(1970, 1, 1)
 
     return _total_seconds(delta)
@@ -53,7 +54,12 @@ def _datetime_to_utc_timestamp(dt):
 
 def fake_time():
     if TIME_TO_FREEZE is not None:
-        return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
+        if TIME_TO_FREEZE.tzinfo:
+            return _datetime_to_utc_timestamp(
+                TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None)
+            )
+        else:
+            return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
     else:
         return original_time()
 

--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -91,7 +91,7 @@ def fake_strftime(format, t=None):
 
 def fake_mktime(timetuple):
     if TIME_TO_FREEZE is not None:
-        return calendar.timegm(timetuple)
+        return original_mktime(timetuple) - _total_seconds(timedelta(hours=TZ_OFFSET))
     else:
         return original_mktime(timetuple)
 

--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -197,9 +197,13 @@ class FakeDatetime(datetime):
         assert tz is None or isinstance(tz, tzinfo)
         global TIME_TO_FREEZE
 
-        if TIME_TO_FREEZE:
+        if TIME_TO_FREEZE and tz is None:
+            # Standard library docs say
+            # the timestamp is converted to the platform's local date and time,
+            # and the returned datetime object is naive.
             _datetime = (
-                original_datetime.fromtimestamp(timestamp, utc).replace(tzinfo=tz or TIME_TO_FREEZE.tzinfo)
+                original_datetime.fromtimestamp(timestamp, utc).replace(tzinfo=None) +
+                timedelta(hours=TZ_OFFSET)
             )
         else:
             _datetime = original_datetime.fromtimestamp(timestamp, tz)

--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -54,12 +54,7 @@ def _datetime_to_utc_timestamp(dt):
 
 def fake_time():
     if TIME_TO_FREEZE is not None:
-        if TIME_TO_FREEZE.tzinfo:
-            return _datetime_to_utc_timestamp(
-                TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None)
-            )
-        else:
-            return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
+        return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
     else:
         return original_time()
 
@@ -178,10 +173,7 @@ class FakeDatetime(datetime):
         global TIME_TO_FREEZE
 
         if TIME_TO_FREEZE:
-            if TIME_TO_FREEZE.tzinfo:
-                _datetime = TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None)
-            else:
-                _datetime = TIME_TO_FREEZE.replace(tzinfo=None)
+            _datetime = TIME_TO_FREEZE
         else:
             _datetime = datetime.utcnow()
 
@@ -194,13 +186,7 @@ class FakeDatetime(datetime):
         global TZ_OFFSET
 
         if TIME_TO_FREEZE:
-            if TIME_TO_FREEZE.tzinfo:
-                if tz:
-                    _datetime = TIME_TO_FREEZE.astimezone(tz) + timedelta(hours=TZ_OFFSET)
-                else:
-                    _datetime = TIME_TO_FREEZE.replace(tzinfo=None) + timedelta(hours=TZ_OFFSET)
-            else:
-                _datetime = TIME_TO_FREEZE.replace(tzinfo=tz) + timedelta(hours=TZ_OFFSET)
+            _datetime = TIME_TO_FREEZE.replace(tzinfo=tz) + timedelta(hours=TZ_OFFSET)
         else:
             _datetime = datetime.now(tz=tz)
 
@@ -238,10 +224,7 @@ class FakeDatetime(datetime):
             raise AttributeError('\'datetime.datetime\' object has no attribute \'timestamp\'')
 
         if TIME_TO_FREEZE:
-            if TIME_TO_FREEZE.tzinfo:
-                return _datetime_to_utc_timestamp(TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None))
-            else:
-                return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
+            return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
         else:
             return super(FakeDatetime, self).timestamp()
 
@@ -312,6 +295,9 @@ class immobilus(object):
 
         if isinstance(self.time_to_freeze, original_date):
             TIME_TO_FREEZE = self.time_to_freeze
+            # Convert to a naive UTC datetime if necessary
+            if TIME_TO_FREEZE.tzinfo:
+                TIME_TO_FREEZE = TIME_TO_FREEZE.astimezone(utc).replace(tzinfo=None)
         else:
             TIME_TO_FREEZE = parser.parse(self.time_to_freeze)
 

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -155,7 +155,7 @@ def test_fromtimestamp():
 
 
 def test_fromtimestamp_with_tz_offset():
-    expected_dt = datetime(1970, 1, 1, 0, 0, tzinfo=None)
+    expected_dt = datetime(1970, 1, 1, 6, tzinfo=None)
     with immobilus('1970-01-01 00:00:01', tz_offset=6):
         dt = datetime.fromtimestamp(0)
 
@@ -163,21 +163,11 @@ def test_fromtimestamp_with_tz_offset():
 
 
 def test_fromtimestamp_with_tz():
-    timezone = pytz.timezone('US/Eastern')
+    timezone = pytz.utc
     expected_dt = datetime(1970, 1, 1, 0, 0, tzinfo=timezone)
 
     with immobilus('1970-01-01 00:00:01'):
         dt = datetime.fromtimestamp(0, timezone)
-
-        assert dt == expected_dt
-
-
-def test_fromtimestamp_takes_tz_from_frozen_datetime():
-    timezone = pytz.timezone('US/Eastern')
-    expected_dt = datetime(1970, 1, 1, 0, 0, tzinfo=timezone)
-
-    with immobilus(datetime(2017, 1, 1, 0, 0, tzinfo=timezone)):
-        dt = datetime.fromtimestamp(0)
 
         assert dt == expected_dt
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -8,11 +8,12 @@ from time import time
 def test_time_function():
 
     dt = datetime(1970, 1, 1)
-    assert _datetime_to_utc_timestamp(dt) == 0.0
-    assert type(_datetime_to_utc_timestamp(dt)) is float
-    assert time() != _datetime_to_utc_timestamp(dt)
+    timestamp = _datetime_to_utc_timestamp(dt)
+    assert timestamp == 0.0
+    assert type(timestamp) is float
+    assert time() != timestamp
 
     with immobilus(dt):
-        assert time() == _datetime_to_utc_timestamp(dt)
+        assert time() == timestamp
 
-    assert time() != _datetime_to_utc_timestamp(dt)
+    assert time() != timestamp

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -4,6 +4,8 @@ from immobilus.logic import _datetime_to_utc_timestamp
 from datetime import datetime
 from time import time
 
+import pytz
+
 
 def test_time_function():
 
@@ -14,6 +16,11 @@ def test_time_function():
     assert time() != timestamp
 
     with immobilus(dt):
+        assert time() == timestamp
+
+    assert time() != timestamp
+
+    with immobilus(dt.replace(tzinfo=pytz.utc)):
         assert time() == timestamp
 
     assert time() != timestamp


### PR DESCRIPTION
```
>>> import datetime, time
>>> import immobilus, pytz
>>>
>>> with immobilus.immobilus(datetime.datetime(2017, 1, 1, tzinfo=pytz.utc)):
...     time.time()
...
Traceback (most recent call last):
  File "<console>", line 2, in <module>
  File "c:\users\day.barr\dev\immobilus\immobilus\logic.py", line 56, in fake_time
    return _datetime_to_utc_timestamp(TIME_TO_FREEZE)
  File "c:\users\day.barr\dev\immobilus\immobilus\logic.py", line 49, in _datetime_to_utc_timestamp
    delta = dt - original_datetime(1970, 1, 1)
  File "c:\users\day.barr\dev\immobilus\immobilus\logic.py", line 160, in __sub__
    result = datetime.__sub__(self, other)
TypeError: can't subtract offset-naive and offset-aware datetimes
```

First 2 commits create a failing test like the above.

Then a targeted fix in the next commit.

Then... maybe I want too far trying to refactor a little? I thought that the code in `logic.py` could be simplified by converting `TIME_TO_FREEZE`  into a naive UTC time just once, when `immobilus.start` is called. Then all the `if TIME_TO_FREEZE.tzinfo` calculations in the various `fake_*` methods can go away - `TIME_TO_FREEZE.tzinfo` will always be `None`, because we converted it to be naive.

This does mean that the behaviour you have in [`FakeDatetime.fromtimestamp`](https://github.com/pokidovea/immobilus/blob/39a0daf08fe6cd43ddf3ab71c17a4f7f20c7ef8e/immobilus/logic.py#L210) to use the timezeone from `TIME_TO_FREEZE`, as tested in [`test_fromtimestamp_takes_tz_from_frozen_datetime`](https://github.com/pokidovea/immobilus/blob/39a0daf08fe6cd43ddf3ab71c17a4f7f20c7ef8e/tests/test_datetime.py#L175-L182) no longer works. Is that really desirable? As far as I can see, this is the only place that really uses `TIME_TO_FREEZE.tzinfo` to affect the result of the function. If we're going to use anything here to fake the "local time", shouldn't it be the `TZ_OFFSET` instead which is intended for exactly that?

I've tried to do that, then fix the resulting knock-on effects this had on some other tests. I *think* the result makes sense to me, although I am quite tired now and must get some sleep ;)

Please let me know if the above (and my changes here) make sense to you, or if I have misunderstood. Thanks.
