### PR TITLE
Enable nesting tz_offset as well

### DIFF
--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -306,7 +306,8 @@ class immobilus(object):
         global TIME_TO_FREEZE
         global TZ_OFFSET
 
-        self.previous_value = TIME_TO_FREEZE
+        self.previous_time_to_freeze = TIME_TO_FREEZE
+        self.previous_tz_offset = TZ_OFFSET
 
         if isinstance(self.time_to_freeze, original_date):
             TIME_TO_FREEZE = self.time_to_freeze
@@ -324,5 +325,5 @@ class immobilus(object):
         global TIME_TO_FREEZE
         global TZ_OFFSET
 
-        TIME_TO_FREEZE = self.previous_value
-        TZ_OFFSET = 0
+        TIME_TO_FREEZE = self.previous_time_to_freeze
+        TZ_OFFSET = self.previous_tz_offset

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -123,6 +123,23 @@ def test_now_with_tz_offset():
         assert dt.tzinfo is None
 
 
+def test_now_with_nested_tz_offset():
+    freeze_time = '2016-01-01 13:54'
+    with immobilus(freeze_time):
+        dt0 = datetime.now()
+        with immobilus(freeze_time, tz_offset=1):
+            dt1 = datetime.now()
+            with immobilus(freeze_time, tz_offset=2):
+                dt2 = datetime.now()
+            dt1_2 = datetime.now()
+        dt0_2 = datetime.now()
+
+    assert dt0 == dt0_2
+    assert dt1 == dt1_2
+    assert dt0 == dt1 - timedelta(hours=1)
+    assert dt0 == dt2 - timedelta(hours=2)
+
+
 def test_now_with_timezone_and_tz_offset():
     timezone = pytz.timezone('Europe/Samara')  # UTC + 4
     with immobilus('2016-01-01 13:54', tz_offset=3):


### PR DESCRIPTION
Nested context managers or decorators worked with `TIME_TO_FREEZE`, but not with `TZ_OFFSET`, as demonstrated in the first commit here with a new test. The second commit fixes it.