### PR TITLE
tox configuration and python 3.8 travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,12 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8-dev
 
-script: make test
+matrix:
+  allow_failures:
+     - python: 3.8-dev
+
+script: tox
 install:
-  - pip install .
-  - pip install -r requirements.txt
+  - pip install tox-travis

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	pytest
+	tox
 
 publish:
 	python setup.py sdist upload

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-glob=README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,11 @@
+[tool:pytest]
+addopts = --doctest-glob=README.md
+
+[tox:tox]
+envlist = py27,py35,py36,py37
+
+[testenv]
+commands = pytest {posargs}
+deps =
+    .
+    -r requirements.txt


### PR DESCRIPTION
This PR adds a tox configuration so we can test all python version in a development environment.
It also adds a python38 travis check that is allowed to fail.