### PR TITLE
Implemented tick method

### DIFF
--- a/immobilus/logic.py
+++ b/immobilus/logic.py
@@ -254,6 +254,10 @@ class FakeDatetime(datetime):
         except AttributeError:
             return 0
 
+    def tick(self, delta=timedelta(seconds=1)):
+        global TIME_TO_FREEZE
+        TIME_TO_FREEZE += delta
+
 
 def pickle_fake_date(datetime_):
     # A pickle function for FakeDate
@@ -323,6 +327,7 @@ class _immobilus(object):
 
     def __enter__(self):
         self.start()
+        return TIME_TO_FREEZE
 
     def __exit__(self, *args):
         self.stop()

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -1,7 +1,7 @@
 from immobilus.logic import immobilus
 
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def test_transmutations():
@@ -19,3 +19,12 @@ def test_transmutations():
         fromtimestamp = datetime.fromtimestamp(mktime)
 
         assert now.replace(microsecond=0) == fromtimestamp
+
+
+def test_tick():
+    with immobilus('2019-08-21 12:00:00') as dt:
+        assert datetime(2019, 8, 21, 12, 0, 0) == datetime.now()
+        dt.tick()
+        assert datetime(2019, 8, 21, 12, 0, 1) == datetime.now()
+        dt.tick(timedelta(seconds=10))
+        assert datetime(2019, 8, 21, 12, 0, 11) == datetime.now()


### PR DESCRIPTION
Like the one in [freezegun](https://github.com/spulec/freezegun/blob/7648175e31e52dcb16f43aa7130e45415c05313e/freezegun/api.py#L455) and the one in [libfaketime](https://github.com/simon-weber/python-libfaketime/blob/master/libfaketime/__init__.py#L159).

I made `tick` a method of the `_immobilus` class, and not the `FakeDatetime` class because I wanted `FakeDatetime` to have the same API as `datetime`, but I would understand if you prefer `tick` to be part of `FakeDatetime` instead.